### PR TITLE
Remove geo.API_KEY from AndroidManifest.xml

### DIFF
--- a/Android/mobile/src/main/res/values/strings.xml
+++ b/Android/mobile/src/main/res/values/strings.xml
@@ -20,11 +20,8 @@
     <string name="arriving_in">Arriving in</string>
     <string name="arriving_units">minutes</string>
 
-    <!--<string name="google_api_android_key">AIzaSyDBi8DUOIlJUouoNL8sgrIluGb30gBr6K8</string>-->
-
-
   <!--
-    Light theme -->
+  Light theme -->
     <color name="blue_curr">#335E7F</color>
     <color name="orange_curr">#FB9D50</color>
     <color name="grey_curr">#BCD0D1</color>
@@ -37,9 +34,5 @@
     <color name="red_curr">#277F72</color>
     <color name="yellow_curr">#C7A63F</color>
     <color name="green_curr">#277F72</color>
-
-
   -->
-
-
 </resources>

--- a/Android/mobile/src/main/res/values/strings.xml
+++ b/Android/mobile/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
 
     <string name="arriving_in">Arriving in</string>
     <string name="arriving_units">minutes</string>
-
+    
   <!--
   Light theme -->
     <color name="blue_curr">#335E7F</color>

--- a/Android/wear/src/main/AndroidManifest.xml
+++ b/Android/wear/src/main/AndroidManifest.xml
@@ -46,9 +46,6 @@
             </intent-filter>
         </service>
         <meta-data
-            android:name="com.google.android.geo.API_KEY"
-            android:value="@string/GEO_API_KEY"/>
-        <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
     </application>

--- a/Android/wear/src/main/AndroidManifest.xml
+++ b/Android/wear/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
         </service>
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyDBi8DUOIlJUouoNL8sgrIluGb30gBr6K8"/>
+            android:value="@string/GEO_API_KEY"/>
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />


### PR DESCRIPTION
(I thought I created this the other day when I pushed `api-key-removal`)

Anyhow, @kneisess while you're swapping out API keys (per #38), please test the use of `privateconstants.xml` in lieu of encoding the value in `AndroidManifest.xml`.  IIRC this didn't work for some odd reason during development, but (at least according to StackOverflow) it should work given the changes in this PR.  

Assuming all is well please assign back to me to merge (or merge yourself if you'd prefer)!